### PR TITLE
Update signature for api.sendMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -641,8 +641,9 @@ declare namespace Facebook
          * @param message a string or a message object
          * @param threadID thread id(s)
          * @param callback callback called when sending the message is done
+         * @param messageID messageID of the message being replied to
          */
-        public sendMessage(message: string | Facebook.IMessage, threadID: string | Array<string>, callback: (err: Facebook.IError, messageInfo: Facebook.IMessageInfo) => void): void;
+        public sendMessage(message: string | Facebook.IMessage, threadID: string | Array<string>, callback?: (err: Facebook.IError, messageInfo: Facebook.IMessageInfo) => void, messageID?: string): void;
 
         /**
          * 


### PR DESCRIPTION
Fixes a couple things for `api.sendMessage`:

1) The `callback` should be optional
2) An additional optional `messageID` parameter has been added since this function was last updated

([docs](https://github.com/Schmavery/facebook-chat-api/blob/master/DOCS.md#apisendmessagemessage-threadid-callback-messageid))

Thanks for writing these type definitions!